### PR TITLE
Fix TRAPI version on sub-service calls

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -45,7 +45,10 @@ async def lookup(
     async with httpx.AsyncClient() as client:
         response = await client.post(
             "https://automat.renci.org/robokopkg/1.1/query",
-            json=request.dict(),
+            json=request.dict(
+                by_alias=True,
+                exclude_unset=True,
+            ),
         )
         response = await client.post(
             "https://aragorn-ranker.renci.org/1.1/omnicorp_overlay",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ fastapi==0.63.0
 httpx==0.16.1
 httpcore==0.12.3
 reasoner-pydantic==1.1.1
+reasoner-validator==2.0.0
 uvicorn==0.13.3

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,7 +8,7 @@ from asgiar import ASGIAR
 from fastapi import FastAPI
 import httpx
 import pytest
-from reasoner_pydantic import Query
+from starlette.requests import Request
 
 from app.server import APP
 
@@ -35,8 +35,8 @@ async def function_overlay(host: str, fcn: Callable):
             "/{path:path}",
             methods=["GET", "POST", "PUT", "DELETE"],
         )
-        async def all_paths(path: str, request: Query):
-            return fcn(request.dict())
+        async def all_paths(path: str, request: Request):
+            return fcn(await request.json())
 
         await stack.enter_async_context(
             ASGIAR(app, host=host)


### PR DESCRIPTION
The foolish alias business in reasoner-pydantic 1.1.x causes all sorts of confusion.